### PR TITLE
feat: detail page whether to display github icon

### DIFF
--- a/lib/src/presentation/packages/detail_package_screen.dart
+++ b/lib/src/presentation/packages/detail_package_screen.dart
@@ -557,14 +557,18 @@ class DetailPackageScreenState extends State<DetailPackageScreen>
                     ),
                     onPressed: () =>
                         Util.shareProject(package: _model.package)),
-              if (_model.hasData && !_model.isBusy)
-                IconButton(
-                    icon: CustomIcon(
-                      icon: 'github',
-                      size: 20,
-                    ),
-                    onPressed: () => Util.openLink(
-                        url: _model.package.latest.pubspec.homepage))
+              if (_model.hasData && !_model.isBusy) Builder(builder: (context) {
+                var _homePage = _model.package.latest.pubspec.homepage;
+                if (_homePage.isNotEmpty)
+                  return IconButton(
+                      icon: CustomIcon(
+                        icon: 'github',
+                        size: 20,
+                      ),
+                      onPressed: () => Util.openLink(
+                          url: _homePage));
+                return SizedBox.shrink();
+              })
             ],
             elevation: 0.0,
             title: Text(


### PR DESCRIPTION
if there is not `homepage`, then the `github icon` should not be displayed

![t](https://user-images.githubusercontent.com/45585937/161482466-18ac5557-4251-4333-8a0d-fbe03b0717f5.gif)
